### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -26,7 +26,7 @@ after_initialize do
           end
         end
 
-        class PerMinuteChecker < Jobs::Scheduled
+        class PerMinuteChecker < ::Jobs::Scheduled
           every 10.seconds
 
           def execute(args)
@@ -36,7 +36,7 @@ after_initialize do
           end
         end
 
-        class PerHourChecker < Jobs::Scheduled
+        class PerHourChecker < ::Jobs::Scheduled
           every 10.minute
 
           def execute(args)


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff, Jobs::Base and Jobs::Scheduled without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364